### PR TITLE
Update color-thief.js

### DIFF
--- a/src/color-thief.js
+++ b/src/color-thief.js
@@ -276,8 +276,7 @@ var MMCQ = (function() {
                 for (i = vbox.r1; i <= vbox.r2; i++) {
                     for (j = vbox.g1; j <= vbox.g2; j++) {
                         for (k = vbox.b1; k <= vbox.b2; k++) {
-                             index = getColorIndex(i,j,k);
-                             npix += (histo[index] || 0);
+                             npix += (histo[getColorIndex(i,j,k)] || 0);
                         }
                     }
                 }


### PR DESCRIPTION
Prevent 'index is not defined' error. Could be 'const index = ...' too.